### PR TITLE
Add error handling and configurable retries to curl calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ Parameters:
  * `description` - a short description of the status
  * `description_path` - path to an input file whose data is the value of `description`
  * `target_url` - the target URL to associate with the status (default: concourse build link)
-
+ * `sleep_duration` - the amount of time in seconds to wait while retrying for the status (default: 3)
+ * `max_attempts` - the number of times to retry for the status to be ready (default: 5)
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Parameters:
  * `target_url` - the target URL to associate with the status (default: concourse build link)
  * `sleep_duration` - the amount of time in seconds to wait while retrying for the status (default: 3)
  * `max_attempts` - the number of times to retry for the status to be ready (default: 5)
+ * `retry_timeout` - the amount of time in seconds to wait while retrying for the status (Default: 3)
+ * `retry_count` - the number of times to retry for the status to be ready (Default: 5)
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -43,10 +43,8 @@ Parameters:
  * `description` - a short description of the status
  * `description_path` - path to an input file whose data is the value of `description`
  * `target_url` - the target URL to associate with the status (default: concourse build link)
- * `sleep_duration` - the amount of time in seconds to wait while retrying for the status (default: 3)
- * `max_attempts` - the number of times to retry for the status to be ready (default: 5)
- * `retry_timeout` - the amount of time in seconds to wait while retrying for the status (Default: 3)
- * `retry_count` - the number of times to retry for the status to be ready (Default: 5)
+ * `retry_count` - the number of times to retry for the status to be ready (default: 5)
+ * `retry_delay` - the amount of time in seconds to wait while retrying for the status (default: 3)
 
 ## Example
 

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -50,5 +50,51 @@ curlgh () {
   else
     skip_verify_arg=""
   fi
-  curl $skip_verify_arg -s -H "Authorization: token $source_access_token" $@
+
+  attempts=0
+  maxAttempts="${max_attempts:-5}"
+  sleepDuration="${sleep_duration:-3}"
+  while [[ $attempts -lt $maxAttempts ]]; do
+    attempts=$((attempts+=1))
+    curl $skip_verify_arg -s -D/tmp/responseheaders -H "Authorization: token $source_access_token" $@ > /tmp/rawresponse
+
+    httpStatus=$(head -n1 /tmp/responseheaders | sed 's|HTTP.* \([0-9]*\) .*|\1|')
+    if [[ "$httpStatus" -eq "200" ]]; then # If HTTP status is OK, skip to extracting the statuses
+      break;
+    fi
+
+    # Various error handling (authn, authz, rate-limiting, transient API errors)
+    if [[ "$httpStatus" -ge 400 ]]; then
+      if [[ "$httpStatus" -lt 500 ]]; then # 4XX range
+        if [[ $(grep -i 'rate-limit' /tmp/rawresponse || echo '0') -ge 1 ]]; then
+          now=$(date "+%s")
+          ratelimitReset=$(cat /tmp/responseheaders | sed -n 's|X-RateLimit-Reset: \([0-9]*\)|\1|p')
+
+          sleepDuration=$((ratelimitReset-now))
+          if [[ "$sleepDuration" -lt 1 ]]; then # Protects against timing issue
+            sleepDuration=1
+          fi
+          echo "Limited by the API rate limit. Script will retry at $(date -d@$((now+sleepDuration)))" >&2
+        else
+          fatal "Authentication error against the GitHub API"
+        fi
+      else # 5XX range
+        echo "Unexpected HTTP $(echo $httpStatus) when querying the GitHub API" >&2
+        sleepDuration=5
+      fi
+    else # Other status code that's not 200 OK, nor in the 400+ range
+      fatal "Unexpected HTTP status code when querying the GitHub API: $(echo $httpStatus)"
+    fi
+
+    # Exit if we have reach the maximum number of attemps, or sleep and retry otherwise
+    if [[ $attempts -eq $maxAttempts ]]; then
+      fatal "Maximum number of attempts reached while trying to query the GitHub API"
+    else
+      echo "Will retry in $sleepDuration seconds" >&2
+      sleep $sleepDuration
+    fi
+
+  done
+
+  cat /tmp/rawresponse
 }

--- a/bin/in
+++ b/bin/in
@@ -11,6 +11,13 @@ eval $( jq -r '{
   "version_status": .version.status
 } | to_entries[] | .key + "=" + @sh "\(.value)"' < /tmp/stdin )
 
+#
+# check retry counter
+#
+
+REMAINING_TRIES="${retry_count:-5}"
+
+while true; do
 
 #
 # lookup
@@ -30,9 +37,24 @@ curlgh "$source_endpoint/repos/$source_repository/commits/$version_commit/status
 # validate
 #
 
-jq -e '.status' < /tmp/status > /dev/null \
-  || fatal "Status not found on $( jq -r '.sha' < /tmp/status )"
+jq -e '.status' < /tmp/status > /dev/null
+check_status="$?"
 
+if [ "$check_status" -eq 0 ]; then
+  break
+elif [ "$check_status" -gt 0 ] && [ "$REMAINING_TRIES" -le 1 ]; then
+  fatal "Status not found on $( jq -r '.sha' < /tmp/status )"
+fi
+
+#
+# decrease retry counter and loop
+#
+
+REMAINING_TRIES=$(($REMAINING_TRIES - 1))
+
+sleep "${retry_timeout:-3}"
+
+done
 
 #
 # concourse

--- a/bin/in
+++ b/bin/in
@@ -32,17 +32,17 @@ curlgh "$source_endpoint/repos/$source_repository/commits/$version_commit/status
     }' \
     > /tmp/status
 
-
 #
 # validate
 #
-
+set +e
 jq -e '.status' < /tmp/status > /dev/null
 check_status="$?"
+set -e
 
 if [ "$check_status" -eq 0 ]; then
   break
-elif [ "$check_status" -gt 0 ] && [ "$REMAINING_TRIES" -le 1 ]; then
+elif [ "$check_status" -gt 0 ] && [ "$REMAINING_TRIES" -le 0 ]; then
   fatal "Status not found on $( jq -r '.sha' < /tmp/status )"
 fi
 
@@ -52,7 +52,7 @@ fi
 
 REMAINING_TRIES=$(($REMAINING_TRIES - 1))
 
-sleep "${retry_timeout:-3}"
+sleep "${retry_delay:-3}"
 
 done
 

--- a/bin/out
+++ b/bin/out
@@ -112,12 +112,14 @@ curlgh "$source_endpoint/repos/$source_repository/commits/$source_branch/status"
 # validate
 #
 
+set +e
 jq -e '.status' < /tmp/status > /dev/null
 check_status="$?"
+set -e
 
 if [ "$check_status" -eq 0 ]; then
   break
-elif [ "$check_status" -gt 0 ] && [ "$REMAINING_TRIES" -le 1 ]; then
+elif [ "$check_status" -gt 0 ] && [ "$REMAINING_TRIES" -le 0 ]; then
   fatal "Status not found on $( jq -r '.sha' < /tmp/status )"
 fi
 
@@ -127,7 +129,7 @@ fi
 
 REMAINING_TRIES=$(($REMAINING_TRIES - 1))
 
-sleep "${retry_timeout:-3}"
+sleep "${retry_delay:-3}"
 
 done
 

--- a/bin/out
+++ b/bin/out
@@ -88,14 +88,6 @@ jq -c -n \
     > /tmp/gh-result
 
 #
-# check retry counter
-#
-
-REMAINING_TRIES=5
-
-while [[ $REMAINING_TRIES -gt 0 ]]; do
-
-#
 # lookup
 #
 
@@ -115,16 +107,6 @@ curlgh "$source_endpoint/repos/$source_repository/commits/$source_branch/status"
 [[ -s /tmp/status ]] \
   && jq -e '.status' < /tmp/status > /dev/null \
   && break
-
-#
-# decrease retry counter and loop
-#
-
-REMAINING_TRIES=$(($REMAINING_TRIES - 1))
-
-sleep 1
-
-done
 
 #
 # concourse

--- a/bin/out
+++ b/bin/out
@@ -88,6 +88,14 @@ jq -c -n \
     > /tmp/gh-result
 
 #
+# check retry counter
+#
+
+REMAINING_TRIES="${retry_count:-5}"
+
+while true; do
+
+#
 # lookup
 #
 
@@ -104,9 +112,24 @@ curlgh "$source_endpoint/repos/$source_repository/commits/$source_branch/status"
 # validate
 #
 
-[[ -s /tmp/status ]] \
-  && jq -e '.status' < /tmp/status > /dev/null \
-  && break
+jq -e '.status' < /tmp/status > /dev/null
+check_status="$?"
+
+if [ "$check_status" -eq 0 ]; then
+  break
+elif [ "$check_status" -gt 0 ] && [ "$REMAINING_TRIES" -le 1 ]; then
+  fatal "Status not found on $( jq -r '.sha' < /tmp/status )"
+fi
+
+#
+# decrease retry counter and loop
+#
+
+REMAINING_TRIES=$(($REMAINING_TRIES - 1))
+
+sleep "${retry_timeout:-3}"
+
+done
 
 #
 # concourse

--- a/test/in/error-503.sh
+++ b/test/in/error-503.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+set -eu
+
+DIR=$( dirname "$0" )/../..
+
+cat <<EOF | nc -l -s 127.0.0.1 -p 9192 > $TMPDIR/http.req-$$ &
+HTTP/1.0 503 Service Unavailable
+
+EOF
+
+in_dir=$TMPDIR/status-$$
+
+mkdir $in_dir
+
+set +e
+
+$DIR/bin/in "$in_dir" > $TMPDIR/resource-$$ 2>&1 <<EOF
+{
+  "version": {
+    "commit": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+    "status": "2"
+  },
+  "source": {
+    "access_token": "test-token",
+    "context": "test-context",
+    "endpoint": "http://127.0.0.1:9192",
+    "repository": "dpb587/test-repo"
+  }
+}
+EOF
+
+exitcode=$?
+
+set -e
+
+if ! [ "1" == "$exitcode" ] ; then
+  echo "FAILURE: Expected exit code 1"
+  exit 1
+fi
+
+if ! grep -q 'Status not found on 6dcb09b5b57875f334f61aebed695e2e4193db5e' $TMPDIR/resource-$$ ; then
+  echo "FAILURE: Unexpected failure message"
+  cat $TMPDIR/resource-$$
+  exit 1
+fi

--- a/test/in/missing-status.sh
+++ b/test/in/missing-status.sh
@@ -19,7 +19,7 @@ mkdir $in_dir
 
 set +e
 
-$DIR/bin/in "$in_dir" > $TMPDIR/resource-$$ 2>&1 <<EOF
+retry_count=0 $DIR/bin/in "$in_dir" > $TMPDIR/resource-$$ 2>&1 <<EOF
 {
   "version": {
     "commit": "6dcb09b5b57875f334f61aebed695e2e4193db5e",


### PR DESCRIPTION
I mashed together @aleveille and @avanier 's commits to improve the rate-limiting situation on this resource (all credit to them!).

They:
- Improved the error messages if the status request fails
- Added retries for both operations (in/out)
- Made the retry count + timing configurable

I removed the retry from the `out` operation, since now it's covered by the `common` file. It was originally added in [dpb587/github-status-resource/pull/4](https://github.com/dpb587/github-status-resource/pull/4/files). I'm not sure if I should remove all the code (and the test) that was added in that PR? 